### PR TITLE
Remove www.whatdotheyknow.com

### DIFF
--- a/Lite/adblock.txt
+++ b/Lite/adblock.txt
@@ -31560,7 +31560,6 @@
 ||whalepp.com^
 ||whaleserver.com^
 ||whallc.com^
-||www.whatdotheyknow.com^
 ||ttauri.whathifi.com^
 ||clicks.whatifoffers.com^
 ||tracking.whatsappbgr.com^

--- a/Lite/dnsmasq.conf
+++ b/Lite/dnsmasq.conf
@@ -31560,7 +31560,6 @@ server=/www.whalecloud.com/
 server=/whalepp.com/
 server=/whaleserver.com/
 server=/whallc.com/
-server=/www.whatdotheyknow.com/
 server=/ttauri.whathifi.com/
 server=/clicks.whatifoffers.com/
 server=/tracking.whatsappbgr.com/

--- a/Lite/domains.txt
+++ b/Lite/domains.txt
@@ -45559,7 +45559,6 @@ www.whalecloud.com
 whalepp.com
 whaleserver.com
 whallc.com
-www.whatdotheyknow.com
 ttauri.whathifi.com
 clicks.whatifoffers.com
 tracking.whatsappbgr.com

--- a/Lite/hosts.txt
+++ b/Lite/hosts.txt
@@ -45573,7 +45573,6 @@ ff02::3 ip6-allhosts
 0.0.0.0 whalepp.com
 0.0.0.0 whaleserver.com
 0.0.0.0 whallc.com
-0.0.0.0 www.whatdotheyknow.com
 0.0.0.0 ttauri.whathifi.com
 0.0.0.0 clicks.whatifoffers.com
 0.0.0.0 tracking.whatsappbgr.com

--- a/Lite/wildcards.txt
+++ b/Lite/wildcards.txt
@@ -31560,7 +31560,6 @@
 *.whalepp.com
 *.whaleserver.com
 *.whallc.com
-*.www.whatdotheyknow.com
 *.ttauri.whathifi.com
 *.clicks.whatifoffers.com
 *.tracking.whatsappbgr.com

--- a/Pro/adblock.txt
+++ b/Pro/adblock.txt
@@ -59744,7 +59744,6 @@
 ||whatcoronavirus.com^
 ||whatcoronavirustaughtus.com^
 ||whatcounts.com^
-||www.whatdotheyknow.com^
 ||ttauri.whathifi.com^
 ||clicks.whatifoffers.com^
 ||whatis.com^

--- a/Pro/dnsmasq.conf
+++ b/Pro/dnsmasq.conf
@@ -59744,7 +59744,6 @@ server=/search.wharkike.com/
 server=/whatcoronavirus.com/
 server=/whatcoronavirustaughtus.com/
 server=/whatcounts.com/
-server=/www.whatdotheyknow.com/
 server=/ttauri.whathifi.com/
 server=/clicks.whatifoffers.com/
 server=/whatis.com/

--- a/Pro/domains.txt
+++ b/Pro/domains.txt
@@ -107526,7 +107526,6 @@ siteanalytics.whatcounts.com
 siteanalytics2.whatcounts.com
 static.whatcounts.com
 tracking.whatcounts.com
-www.whatdotheyknow.com
 ttauri.whathifi.com
 clicks.whatifoffers.com
 whatis.com

--- a/Pro/wildcards.txt
+++ b/Pro/wildcards.txt
@@ -59744,7 +59744,6 @@
 *.whatcoronavirus.com
 *.whatcoronavirustaughtus.com
 *.whatcounts.com
-*.www.whatdotheyknow.com
 *.ttauri.whathifi.com
 *.clicks.whatifoffers.com
 *.whatis.com

--- a/Pro/xtra/adblock.txt
+++ b/Pro/xtra/adblock.txt
@@ -152497,7 +152497,6 @@
 ||what-when-how.com^
 ||whatagraph.com^
 ||whatchristianswanttoknow.com^
-||whatdotheyknow.com^
 ||whateveryf.info^
 ||whatispiping.com^
 ||whatsdata.club^

--- a/Pro/xtra/domains.txt
+++ b/Pro/xtra/domains.txt
@@ -152497,7 +152497,6 @@ wgxiypzu.com
 what-when-how.com
 whatagraph.com
 whatchristianswanttoknow.com
-whatdotheyknow.com
 whateveryf.info
 whatispiping.com
 whatsdata.club

--- a/Pro/xtra/wildcards.txt
+++ b/Pro/xtra/wildcards.txt
@@ -152497,7 +152497,6 @@
 *.what-when-how.com
 *.whatagraph.com
 *.whatchristianswanttoknow.com
-*.whatdotheyknow.com
 *.whateveryf.info
 *.whatispiping.com
 *.whatsdata.club


### PR DESCRIPTION
WhatDoTheyKnow [1] is a service run by mySociety [2] – a registered UK
charity – that allows citizens to make Freedom of Information requests
to UK public authorities.

Looks like we were added in 2b77058, which doesn't offer any insight
into why WhatDoTheyKnow was flagged.

[1] https://www.whatdotheyknow.com/help/about
[2] https://www.mysociety.org/about/