### PR TITLE
remove "italia.it" records

### DIFF
--- a/Pro/adblock.txt
+++ b/Pro/adblock.txt
@@ -79586,7 +79586,6 @@
 ||metrics.ionos.it^
 ||stat.ipsoa.it^
 ||istri.it^
-||italia.it^
 ||tracy-moqu.italiaonline.it^
 ||itrac.it^
 ||itrack.it^

--- a/Pro/dnsmasq.conf
+++ b/Pro/dnsmasq.conf
@@ -79586,7 +79586,6 @@ server=/www.iolam.it/
 server=/metrics.ionos.it/
 server=/stat.ipsoa.it/
 server=/istri.it/
-server=/italia.it/
 server=/tracy-moqu.italiaonline.it/
 server=/itrac.it/
 server=/itrack.it/

--- a/Pro/domains.txt
+++ b/Pro/domains.txt
@@ -132063,7 +132063,6 @@ www.iolam.it
 metrics.ionos.it
 stat.ipsoa.it
 istri.it
-italia.it
 tracy-moqu.italiaonline.it
 itrac.it
 static.itrac.it

--- a/Pro/hosts.txt
+++ b/Pro/hosts.txt
@@ -132077,7 +132077,6 @@ ff02::3 ip6-allhosts
 0.0.0.0 metrics.ionos.it
 0.0.0.0 stat.ipsoa.it
 0.0.0.0 istri.it
-0.0.0.0 italia.it
 0.0.0.0 tracy-moqu.italiaonline.it
 0.0.0.0 itrac.it
 0.0.0.0 static.itrac.it

--- a/Pro/wildcards.txt
+++ b/Pro/wildcards.txt
@@ -79586,7 +79586,6 @@
 *.metrics.ionos.it
 *.stat.ipsoa.it
 *.istri.it
-*.italia.it
 *.tracy-moqu.italiaonline.it
 *.itrac.it
 *.itrack.it


### PR DESCRIPTION
Blocking "italia.it" would mean blocking many sites and services of the Italian Republic, including:

- backend of the "IO" app which provides public administration services;
- ns.italia.it and mx.italia.it (used for government accounts);
- docs.italia.it (used for public and government documents);
- cloud.italia.it;
- many other services.

All these services are of very close public utility and do not spread trackers or malware.