### PR TITLE
Umbrella Popularity List

### DIFF
--- a/-data/lists/assets.txt
+++ b/-data/lists/assets.txt
@@ -186,7 +186,6 @@ http://www.hostsfile.org/Downloads/BadHosts.unx.zip
 https://github.com/soteria-nou/domain-list/archive/master.zip
 https://github.com/eEIi0A5L/adblock_filter/archive/master.zip
 https://urlhaus.abuse.ch/downloads/csv/
-http://s3-us-west-1.amazonaws.com/umbrella-static/top-1m.csv.zip
 https://blocklistproject.github.io/Lists/alt-version/abuse-nl.txt
 https://blocklistproject.github.io/Lists/alt-version/ads-nl.txt
 https://blocklistproject.github.io/Lists/alt-version/fraud-nl.txt


### PR DESCRIPTION
https://github.com/badmojr/1Hosts/issues/437#issuecomment-1046307219
https://s3-us-west-1.amazonaws.com/umbrella-static/index.html
"The popularity list contains our most queried domains based on passive DNS usage across our Umbrella global network of more than 100 Billion requests per day with 65 million unique active users, in more than 165 countries. [..] takes in to account the number of unique client IPs invoking this domain relative to the sum of all requests to all domains."