### PR TITLE
🚸 Remove false positive ip-api.com

### DIFF
--- a/Pro/adblock.txt
+++ b/Pro/adblock.txt
@@ -39563,7 +39563,6 @@
 ||iptarunataruna.com^
 ||iptautup.com^
 ||metric.ipv6test.com^
-||ip-api.com^
 ||www.ip-tool.com^
 ||ibd-as-api.iq.com^
 ||iqasearch.com^

--- a/Pro/dnsmasq.conf
+++ b/Pro/dnsmasq.conf
@@ -39563,7 +39563,6 @@ server=/api.ipstack.com/
 server=/iptarunataruna.com/
 server=/iptautup.com/
 server=/metric.ipv6test.com/
-server=/ip-api.com/
 server=/www.ip-tool.com/
 server=/ibd-as-api.iq.com/
 server=/iqasearch.com/

--- a/Pro/domains.txt
+++ b/Pro/domains.txt
@@ -67633,7 +67633,6 @@ iptarunataruna.com
 iptautup.com
 metric.ipv6test.com
 dzc-v6exp3-ds.metric.ipv6test.com
-ip-api.com
 pro.ip-api.com
 www.ip-tool.com
 ibd-as-api.iq.com

--- a/Pro/domains.wildcards
+++ b/Pro/domains.wildcards
@@ -39563,7 +39563,6 @@ api.ipstack.com
 iptarunataruna.com
 iptautup.com
 metric.ipv6test.com
-ip-api.com
 www.ip-tool.com
 ibd-as-api.iq.com
 iqasearch.com

--- a/Pro/hosts.txt
+++ b/Pro/hosts.txt
@@ -67647,7 +67647,6 @@ ff02::3 ip6-allhosts
 0.0.0.0 iptautup.com
 0.0.0.0 metric.ipv6test.com
 0.0.0.0 dzc-v6exp3-ds.metric.ipv6test.com
-0.0.0.0 ip-api.com
 0.0.0.0 pro.ip-api.com
 0.0.0.0 www.ip-tool.com
 0.0.0.0 ibd-as-api.iq.com

--- a/Pro/hosts.win
+++ b/Pro/hosts.win
@@ -7544,7 +7544,7 @@ ff02::3 ip6-allhosts
 0.0.0.1 fra1.ipromote.com fra2.ipromote.com i.ipromote.com iad1.ipromote.com iad2.ipromote.com iad3.ipromote.com iad4.ipromote.com iad5.ipromote.com iad6.ipromote.com
 0.0.0.1 iad7.ipromote.com iad8.ipromote.com search.ipromote.com servedby.ipromote.com sfo1.ipromote.com sfo2.ipromote.com sfo3.ipromote.com sfo4.ipromote.com sin1.ipromote.com
 0.0.0.1 sin2.ipromote.com www.ipromote.com iprospect.com iprotech.com iprotrk.com iproute66.com www.iproute66.com tr.cacf.ipsos-surveys.com tr.cacf-acq.ipsos-surveys.com
-0.0.0.1 ipsowrite.com ipssss.com api.ipstack.com iptarunataruna.com iptautup.com metric.ipv6test.com dzc-v6exp3-ds.metric.ipv6test.com ip-api.com pro.ip-api.com
+0.0.0.1 ipsowrite.com ipssss.com api.ipstack.com iptarunataruna.com iptautup.com metric.ipv6test.com dzc-v6exp3-ds.metric.ipv6test.com pro.ip-api.com
 0.0.0.1 www.ip-tool.com ibd-as-api.iq.com iqasearch.com affiliate.iqbroker.com tracker.affiliate.iqbroker.com tm.iqfp1.com g3.iqilu.com puma.api.iqiyi.com apisgame.iqiyi.com
 0.0.0.1 api-yuedu.iqiyi.com cards-css.iqiyi.com ckm.iqiyi.com cloudpush.iqiyi.com cmonitor.iqiyi.com cmts.iqiyi.com cook.iqiyi.com cs-feige.iqiyi.com cupid.iqiyi.com
 0.0.0.1 kjp.cupid.iqiyi.com msga.cupid.iqiyi.com resource.cupid.iqiyi.com riskip.cupid.iqiyi.com t7z.cupid.iqiyi.com v6z.cupid.iqiyi.com api.cupid.dns.iqiyi.com du-feige.iqiyi.com dx-cards-css.iqiyi.com

--- a/Pro/rpz.txt
+++ b/Pro/rpz.txt
@@ -79112,8 +79112,6 @@ iptarunataruna.com CNAME .
 iptautup.com CNAME .
 *.metric.ipv6test.com CNAME .
 metric.ipv6test.com CNAME .
-*.ip-api.com CNAME .
-ip-api.com CNAME .
 *.www.ip-tool.com CNAME .
 www.ip-tool.com CNAME .
 *.ibd-as-api.iq.com CNAME .

--- a/Pro/snitch.rules
+++ b/Pro/snitch.rules
@@ -39548,7 +39548,6 @@
     "iptarunataruna.com",
     "iptautup.com",
     "metric.ipv6test.com",
-    "ip-api.com",
     "www.ip-tool.com",
     "ibd-as-api.iq.com",
     "iqasearch.com",

--- a/Pro/unbound.conf
+++ b/Pro/unbound.conf
@@ -39563,7 +39563,6 @@ local-zone: "api.ipstack.com" always_null
 local-zone: "iptarunataruna.com" always_null
 local-zone: "iptautup.com" always_null
 local-zone: "metric.ipv6test.com" always_null
-local-zone: "ip-api.com" always_null
 local-zone: "www.ip-tool.com" always_null
 local-zone: "ibd-as-api.iq.com" always_null
 local-zone: "iqasearch.com" always_null

--- a/Pro/wildcards.txt
+++ b/Pro/wildcards.txt
@@ -39563,7 +39563,6 @@
 *.iptarunataruna.com
 *.iptautup.com
 *.metric.ipv6test.com
-*.ip-api.com
 *.www.ip-tool.com
 *.ibd-as-api.iq.com
 *.iqasearch.com

--- a/Xtra/adblock.txt
+++ b/Xtra/adblock.txt
@@ -79371,7 +79371,6 @@
 ||ipvabcd123.com^
 ||ipvoicenow.com^
 ||ipxretirement.com^
-||ip-api.com^
 ||ip-approval.com^
 ||dns3.ip-asia.com^
 ||dns4.ip-asia.com^

--- a/Xtra/dnsmasq.conf
+++ b/Xtra/dnsmasq.conf
@@ -79371,7 +79371,6 @@ server=/metric.ipv6test.com/
 server=/ipvabcd123.com/
 server=/ipvoicenow.com/
 server=/ipxretirement.com/
-server=/ip-api.com/
 server=/ip-approval.com/
 server=/dns3.ip-asia.com/
 server=/dns4.ip-asia.com/

--- a/Xtra/domains.txt
+++ b/Xtra/domains.txt
@@ -153705,7 +153705,6 @@ www.ipvabcd123.com
 ipvoicenow.com
 ipxretirement.com
 myira-balance.ipxretirement.com
-ip-api.com
 pro.ip-api.com
 ip-approval.com
 www.ip-approval.com

--- a/Xtra/domains.wildcards
+++ b/Xtra/domains.wildcards
@@ -79371,7 +79371,6 @@ metric.ipv6test.com
 ipvabcd123.com
 ipvoicenow.com
 ipxretirement.com
-ip-api.com
 ip-approval.com
 dns3.ip-asia.com
 dns4.ip-asia.com

--- a/Xtra/hosts.txt
+++ b/Xtra/hosts.txt
@@ -153719,7 +153719,6 @@ ff02::3 ip6-allhosts
 0.0.0.0 ipvoicenow.com
 0.0.0.0 ipxretirement.com
 0.0.0.0 myira-balance.ipxretirement.com
-0.0.0.0 ip-api.com
 0.0.0.0 pro.ip-api.com
 0.0.0.0 ip-approval.com
 0.0.0.0 www.ip-approval.com

--- a/Xtra/hosts.win
+++ b/Xtra/hosts.win
@@ -17108,7 +17108,7 @@ ff02::3 ip6-allhosts
 0.0.0.1 www.ips-docs.com iptarunataruna.com iptautup.com iptoasn.com iptv2021.com pl.iptv2021.com iptv2022.com assets.iptv2022.com epg.iptv2022.com
 0.0.0.1 info.iptv2022.com mhd.iptv2022.com mhd109.iptv2022.com iptvmanagerpro.com mus.iptvmanagerpro.com providers.iptvmanagerpro.com tv.iptvmanagerpro.com iptwins.com ns3.iptwins.com
 0.0.0.1 ns4.iptwins.com ipublishcentral.com jlg.ipublishcentral.com metric.ipv6test.com dzc-v6exp3-ds.metric.ipv6test.com ipvabcd123.com cdn.ipvabcd123.com tn.ipvabcd123.com www.ipvabcd123.com
-0.0.0.1 ipvoicenow.com ipxretirement.com myira-balance.ipxretirement.com ip-api.com pro.ip-api.com ip-approval.com www.ip-approval.com dns3.ip-asia.com dns4.ip-asia.com
+0.0.0.1 ipvoicenow.com ipxretirement.com myira-balance.ipxretirement.com pro.ip-api.com ip-approval.com www.ip-approval.com dns3.ip-asia.com dns4.ip-asia.com
 0.0.0.1 www.ip-tool.com ip-who.com ibd-as-api.iq.com iq2020.com gskpbu.iq2020.com iqasearch.com iqbackoffice.com archimedes.iqbackoffice.com affiliate.iqbroker.com
 0.0.0.1 tracker.affiliate.iqbroker.com iqcx.com api.iqcx.com www.iqcx.com iqemo.com prescribe.iqemo.com iqera.com www.iqera.com tm.iqfp1.com
 0.0.0.1 g3.iqilu.com iqisit.com puma.api.iqiyi.com apisgame.iqiyi.com api-yuedu.iqiyi.com cards-css.iqiyi.com ckm.iqiyi.com cloudpush.iqiyi.com cmonitor.iqiyi.com

--- a/Xtra/rpz.txt
+++ b/Xtra/rpz.txt
@@ -158728,8 +158728,6 @@ ipvabcd123.com CNAME .
 ipvoicenow.com CNAME .
 *.ipxretirement.com CNAME .
 ipxretirement.com CNAME .
-*.ip-api.com CNAME .
-ip-api.com CNAME .
 *.ip-approval.com CNAME .
 ip-approval.com CNAME .
 *.dns3.ip-asia.com CNAME .

--- a/Xtra/snitch.rules
+++ b/Xtra/snitch.rules
@@ -79356,7 +79356,6 @@
     "ipvabcd123.com",
     "ipvoicenow.com",
     "ipxretirement.com",
-    "ip-api.com",
     "ip-approval.com",
     "dns3.ip-asia.com",
     "dns4.ip-asia.com",

--- a/Xtra/unbound.conf
+++ b/Xtra/unbound.conf
@@ -79371,7 +79371,6 @@ local-zone: "metric.ipv6test.com" always_null
 local-zone: "ipvabcd123.com" always_null
 local-zone: "ipvoicenow.com" always_null
 local-zone: "ipxretirement.com" always_null
-local-zone: "ip-api.com" always_null
 local-zone: "ip-approval.com" always_null
 local-zone: "dns3.ip-asia.com" always_null
 local-zone: "dns4.ip-asia.com" always_null

--- a/Xtra/wildcards.txt
+++ b/Xtra/wildcards.txt
@@ -79371,7 +79371,6 @@
 *.ipvabcd123.com
 *.ipvoicenow.com
 *.ipxretirement.com
-*.ip-api.com
 *.ip-approval.com
 *.dns3.ip-asia.com
 *.dns4.ip-asia.com


### PR DESCRIPTION
This PR fixes #461 by removing `ip-api.com` from blocklists.