### PR TITLE
Add F11 adserver

### DIFF
--- a/submit_here/include_for_all.txt
+++ b/submit_here/include_for_all.txt
@@ -135,3 +135,22 @@ nitro-discordapp.com
 
 # https://github.com/badmojr/1Hosts/issues/299
 analytics.keepassxc.org
+
+# F11 - factor-eleven.de - Local Advertising Platform
+analytics.f11-ads.com
+at.f11-ads.com
+at1.f11-ads.com
+cdn-de.f11-ads.com
+cdn.f11-ads.com
+ch.f11-ads.com
+de-at.f11-ads.com
+de-de.f11-ads.com
+de-de1.f11-ads.com
+de.f11-ads.com
+de1.f11-ads.com
+dedp.f11-ads.com
+f11-ads.com
+fr.f11-ads.com
+lucy.f11-ads.com
+lucy1.f11-ads.com
+www.f11-ads.com


### PR DESCRIPTION
Factor Eleven - local advertising platform adserver:  is used for ads on sites such as xxxlutz.de and fussball.de.