### PR TITLE
👷 use latest major version for actions/checkout

### DIFF
--- a/.github/workflows/ci_updates.yml
+++ b/.github/workflows/ci_updates.yml
@@ -3,19 +3,19 @@ name: CI
   workflow_dispatch:
   schedule:
     - cron: 5 2 * * *
-    
+
 jobs:
   init:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Prep submit_here
         run: |
           (
           export LC_ALL=C
           umask 022
-          
+
           prints() { sed -e '$a\' "$@"; }
           baseDir="./submit_here"
           edit_files=(exclude_for_all.txt exclude_for_mini_Lite_only.txt include_for_Pro_Xtra_only.txt include_for_all.txt)
@@ -36,7 +36,7 @@ jobs:
           done
           )
         shell: bash
-          
+
       - name: Commit & Push
         uses: actions-js/push@master
         with:
@@ -57,4 +57,4 @@ jobs:
         with:
           retain_days: 1
           keep_minimum_runs: 1
-          
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,14 +10,14 @@ on:
      - 'Lite/**'
      - 'Pro/**'
      - 'Xtra/**'
-    
+
 jobs:
   create_release:
     runs-on: ubuntu-latest
 
     steps:
       - name: Clone Repo
-        uses: "actions/checkout@v2.3.4"
+        uses: "actions/checkout@v4"
         with:
           ref: ${{ github.head_ref }}
 
@@ -51,6 +51,6 @@ jobs:
         uses: dev-drprasad/delete-older-releases@v0.1.0
         with:
           keep_latest: 1
-          delete_tags: true 
+          delete_tags: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Use latest major version of [actions/checkout](https://github.com/actions/checkout) for GitHub Actions.