### PR TITLE
Modifying a domain that breaks web pages in Lite/adblock

### DIFF
--- a/Lite/adblock.txt
+++ b/Lite/adblock.txt
@@ -4087,7 +4087,6 @@
 ||modoro360.com^
 ||analytics.126.net^
 ||p.flourstech.com^
-||html-load.com^
 ||doublepimp.com^
 ||revcatch.com^
 ||content.pendo.udsrv.com^
@@ -12028,7 +12027,6 @@
 ||content.product.provationapex.com^
 ||convers.link^
 ||counter.websiteout.net^
-||css-load.com^
 ||data-5c8ddfc1d2.selbst.de^
 ||data.guide-ringlead.zoominfo.co^
 ||data.pendorg.serviceassistant.com^


### PR DESCRIPTION
Blocking that domain will break the web page.
The lite version has to protect UX unlike pro and extra. However, blocking that domain will break the webpage and harm UI/UX.
I think it would be good to allow those domains for users.
client : Adaway

**domain allow list**
- html-load.com
- css-load.com

<details>
<summary>dogdrip.net</summary>
<img width="410" alt="image" src="https://github.com/badmojr/1Hosts/assets/160719549/b3c4e7fd-67b3-4ce2-b5ba-1a6ae21fe819">
</details>
<details>
<summary>worldhistory.org</summary>
<img width="374" alt="image" src="https://github.com/badmojr/1Hosts/assets/160719549/ba621300-ce69-42d3-b5dc-bede6adea05a">
</details>
<h3>Refer this issue</h3>
<a href="https://www.github.com/badmojr/1Hosts/issues/1685">#1685</a>