### PR TITLE
chore: whitelist idtech.no domains

### DIFF
--- a/submit_here/click_me_to_edit/exclude_for_all.txt
+++ b/submit_here/click_me_to_edit/exclude_for_all.txt
@@ -1,0 +1,5 @@
+idtech.no
+oidc.idtech.no
+browser-report.preview.oidc.idtech.no
+preview.oidc.idtech.no
+browser-report.oidc.idtech.no


### PR DESCRIPTION
Context: 
- https://github.com/mitchellkrogza/phishing/pull/380
- https://github.com/mitchellkrogza/phishing/issues/382

These domains (*.idtech.no) host test environments for my employer and are visited by integrators, not end users at large.


#### Possible reasons we were flagged to begin with: 

We (BankID) use CSP policies to enforce secure environments for our end users as breaches could lead to losing their life savings, seeing as BankID is accepted as the login provided for _all_ Norwegian banks.

We strictly adhere to GDPR.

Some of these services are OIDC implementation, which can involve chaining multiple redirects in order to transport authentication codes via URL though multiple layers of OIDC flows. These redirect chains may be interpreted by some as tracking, but we do not track our users other than what's described in our privacy policy in order to protect their digital identity, which all banks and all end users who use our product have explicitly agreed to.

For more info on BankID, see https://bankid.no/en/what-is-bankid

Closes https://github.com/badmojr/1Hosts/issues/1758
