### PR TITLE
Update OpenPhish feed URL to new GitHub location

### DIFF
--- a/-data/lists/assets.txt
+++ b/-data/lists/assets.txt
@@ -10,7 +10,7 @@ https://filters.adtidy.org/extension/chromium/filters/16.txt
 https://filters.adtidy.org/extension/chromium/filters/6.txt
 https://filters.adtidy.org/extension/chromium/filters/7.txt
 https://filters.adtidy.org/extension/chromium/filters/11.txt
-https://openphish.com/feed.txt
+https://raw.githubusercontent.com/openphish/public_feed/refs/heads/main/feed.txt
 https://filters.adtidy.org/extension/chromium/filters/1.txt
 https://filters.adtidy.org/extension/chromium/filters/12.txt
 https://filters.adtidy.org/extension/chromium/filters/9.txt


### PR DESCRIPTION
This PR updates the OpenPhish feed URL to point to their new GitHub-hosted location.

The original feed URL occasionally becomes unavailable, while the GitHub-based feed is now officially listed as a reliable alternative.

Switching to the GitHub feed ensures better reliability and availability of threat intelligence data.